### PR TITLE
Parametrize the fields used for User lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ The following settings can be set in Djangos `settings.py` file:
 
 ## Custom Email Lookup
 
-By default, `email` lookup is used to find the user instance. You can change that by adding
+By default, `email` lookup is used to find the user instance. You can change that or add more matching fields by adding
 
 ```python
-DJANGO_REST_LOOKUP_FIELD = 'custom_email_field'
+DJANGO_REST_LOOKUP_FIELDS = ['custom_email_field', 'other_lookup_field']
 ```
 
 into Django settings.py file.

--- a/django_rest_resetpassword/models.py
+++ b/django_rest_resetpassword/models.py
@@ -10,16 +10,16 @@ from django_rest_resetpassword.tokens import get_token_generator
 # bug report #1297
 # See: https://github.com/tomchristie/django-rest-framework/issues/1297
 
-AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+AUTH_USER_MODEL = getattr(settings, "AUTH_USER_MODEL", "auth.User")
 
 # get the token generator class
 TOKEN_GENERATOR_CLASS = get_token_generator()
 
 __all__ = [
-    'ResetPasswordToken',
-    'get_password_reset_token_expiry_time',
-    'get_password_reset_lookup_field',
-    'clear_expired',
+    "ResetPasswordToken",
+    "get_password_reset_token_expiry_time",
+    "get_password_reset_lookup_field",
+    "clear_expired",
 ]
 
 
@@ -33,29 +33,21 @@ class ResetPasswordToken(models.Model):
         """ generates a pseudo random code using os.urandom and binascii.hexlify """
         return TOKEN_GENERATOR_CLASS.generate_token()
 
-    id = models.AutoField(
-        primary_key=True
-    )
+    id = models.AutoField(primary_key=True)
 
     user = models.ForeignKey(
         AUTH_USER_MODEL,
-        related_name='password_reset_tokens',
+        related_name="password_reset_tokens",
         on_delete=models.CASCADE,
-        verbose_name=_("The User which is associated to this password reset token")
+        verbose_name=_("The User which is associated to this password reset token"),
     )
 
     created_at = models.DateTimeField(
-        auto_now_add=True,
-        verbose_name=_("When was this token generated")
+        auto_now_add=True, verbose_name=_("When was this token generated")
     )
 
     # Key field, though it is not the primary key of the model
-    key = models.CharField(
-        _("Key"),
-        max_length=64,
-        db_index=True,
-        unique=True
-    )
+    key = models.CharField(_("Key"), max_length=64, db_index=True, unique=True)
 
     ip_address = models.GenericIPAddressField(
         _("The IP address of this session"),
@@ -86,7 +78,7 @@ def get_password_reset_token_expiry_time():
     :return: expiry time
     """
     # get token validation time
-    return getattr(settings, 'DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME', 24)
+    return getattr(settings, "DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME", 24)
 
 
 def get_password_reset_lookup_field():
@@ -95,7 +87,19 @@ def get_password_reset_lookup_field():
     Set Django SETTINGS.DJANGO_REST_LOOKUP_FIELD to overwrite this time
     :return: lookup field
     """
-    return getattr(settings, 'DJANGO_REST_LOOKUP_FIELD', 'email')
+    return getattr(settings, "DJANGO_REST_LOOKUP_FIELD", "email")
+
+
+def get_password_reset_lookup_fields():
+    """
+    Returns the password reset lookup fields
+    Set Django SETTINGS.DJANGO_REST_LOOKUP_FIELDS to overwrite this time
+    :return: lookup fields. If not specified, the default DJANGO_REST_LOOKUP_FIELD
+    is used by default.
+    """
+    return getattr(
+        settings, "DJANGO_REST_LOOKUP_FIELDS", [get_password_reset_lookup_field()]
+    )
 
 
 def clear_expired(expiry_time):
@@ -105,17 +109,19 @@ def clear_expired(expiry_time):
     """
     ResetPasswordToken.objects.filter(created_at__lte=expiry_time).delete()
 
+
 def eligible_for_reset(self):
     if not self.is_active:
         # if the user is active we dont bother checking
         return False
- 
-    if getattr(settings, 'DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD', True):
+
+    if getattr(settings, "DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD", True):
         # if we require a usable password then return the result of has_usable_password()
         return self.has_usable_password()
     else:
         # otherwise return True because we dont care about the result of has_usable_password()
         return True
+
 
 # add eligible_for_reset to the user class
 UserModel = get_user_model()

--- a/django_rest_resetpassword/serializers.py
+++ b/django_rest_resetpassword/serializers.py
@@ -3,18 +3,22 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
 __all__ = [
-    'EmailSerializer',
-    'PasswordTokenSerializer',
-    'TokenSerializer',
+    "EmailSerializer",
+    "PasswordTokenSerializer",
+    "TokenSerializer",
 ]
 
 
 class EmailSerializer(serializers.Serializer):
-    email = serializers.EmailField()
+    # This field can contains either a username or an email
+    # but for backward compatibility the field name is kept.
+    email = serializers.CharField()
 
 
 class PasswordTokenSerializer(serializers.Serializer):
-    password = serializers.CharField(label=_("Password"), style={'input_type': 'password'})
+    password = serializers.CharField(
+        label=_("Password"), style={"input_type": "password"}
+    )
     token = serializers.CharField()
 
 

--- a/django_rest_resetpassword/tests.py
+++ b/django_rest_resetpassword/tests.py
@@ -1,7 +1,7 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework.test import APITestCase
-from django.conf import settings
 
 
 class BaseAPITest(APITestCase):

--- a/django_rest_resetpassword/tests.py
+++ b/django_rest_resetpassword/tests.py
@@ -1,0 +1,58 @@
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.conf import settings
+
+
+class BaseAPITest(APITestCase):
+    def setUp(self, password=None) -> None:
+        self.user = User(username="John Smith", email="john@example.com")
+        self.user.set_password("123")
+        self.user.save()
+        self.client.force_authenticate(user=self.user)
+
+    def user_factory(self, username="peter", email="peter@example.com", password="123"):
+        user = User(username=username, email=email, password=password)
+        user.save()
+        return user
+
+
+class ResetPasswordAPITest(BaseAPITest):
+    def test_request_password_with_no_settings(self):
+        # make sure that if no setting, the default password request reset field is the email.
+        user = self.user_factory()
+        data = {"email": user.username}
+        response = self.client.post(reverse("reset-password-request"), data=data)
+        self.assertEqual(response.status_code, 400)
+
+        data = {"email": user.email}
+        response = self.client.post(reverse("reset-password-request"), data=data)
+        self.assertEqual(response.status_code, 200)
+        msg = "A password reset token has been sent to the provided email address"
+        self.assertEqual(response.data["message"], msg)
+
+    def test_request_password_with_django_rest_lookup_field_setting(self):
+        # Make sure we can still use DJANGO_REST_LOOKUP_FIELD  setting for backward compatibility.
+        settings.DJANGO_REST_LOOKUP_FIELD = "username"
+        user = self.user_factory()
+        data = {"email": user.username}
+        response = self.client.post(reverse("reset-password-request"), data=data)
+        self.assertEqual(response.status_code, 200)
+        msg = "A password reset token has been sent to the provided email address"
+        self.assertEqual(response.data["message"], msg)
+
+    def test_request_password_with_django_rest_lookup_fields_setting(self):
+        # Make sure new users can use  DJANGO_REST_LOOKUP_FIELDS  setting.
+        settings.DJANGO_REST_LOOKUP_FIELDS = ["email", "username"]
+        user = self.user_factory()
+        data = {"email": user.username}
+        response = self.client.post(reverse("reset-password-request"), data=data)
+        self.assertEqual(response.status_code, 200)
+        msg = "A password reset token has been sent to the provided email address"
+        self.assertEqual(response.data["message"], msg)
+
+        data = {"email": user.email}
+        response = self.client.post(reverse("reset-password-request"), data=data)
+        self.assertEqual(response.status_code, 200)
+        msg = "A password reset token has been sent to the provided email address"
+        self.assertEqual(response.data["message"], msg)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,7 +17,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '3=5i19f35d^1861(y)0v#ukjdc_e_8c%x6ft8v=m3vr9k6%=k9'
+SECRET_KEY = "3=5i19f35d^1861(y)0v#ukjdc_e_8c%x6ft8v=m3vr9k6%=k9"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -28,43 +28,41 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
     # include django rest framework
-    'rest_framework',
-
+    "rest_framework",
     # include multi token auth
-    'django_rest_resetpassword'
+    "django_rest_resetpassword",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'django_rest_resetpassword.urls'
+ROOT_URLCONF = "django_rest_resetpassword.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
@@ -75,9 +73,9 @@ TEMPLATES = [
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     }
 }
 
@@ -87,16 +85,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -104,9 +102,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -118,4 +116,4 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"


### PR DESCRIPTION
Hi @joshuachinemezu, so actually we needed more changes than initially planned. Instead of adding a new field in the serializer, which makes it very specific to our own use case, we went for a more generic version, with still a single "email" input but that can be used to match different fields.

We've kept backward compatibility with current setting `DJANGO_REST_LOOKUP_FIELD` but added a new `DJANGO_REST_LOOKUP_FIELDS` to specify the fields that can be used for matching.
Finally, we added basic tests to make sure we were not breaking anything, but it still requires manual testing, of course.

Sorry for this long PR, we use black as a formatting engine so the code has been reformatted, let us know if you'd like a non-reformatted version, we'll try to do it.

Co-authored-by: godmind <aristide.bamazi@imsp-uac.org>